### PR TITLE
Update js-example.html

### DIFF
--- a/oembed/js-example.html
+++ b/oembed/js-example.html
@@ -10,7 +10,7 @@
 
         // This is the oEmbed endpoint for Vimeo (we're using JSON)
         // (Vimeo also supports oEmbed discovery. See the PHP example.)
-        var endpoint = 'http://www.vimeo.com/api/oembed.json';
+        var endpoint = 'https://www.vimeo.com/api/oembed.json';
 
         // Tell Vimeo what function to call
         var callback = 'embedVideo';


### PR DESCRIPTION
The old code still works nicely for simple vimeo embedding. However, the endpoint should be changed to https to avoid the possibility of browsers complaining about mixed content