### PR TITLE
Changing video ID to something that exists

### DIFF
--- a/oembed/js-example.html
+++ b/oembed/js-example.html
@@ -6,7 +6,7 @@
     <script>
 
         // This is the URL of the video you want to load
-        var videoUrl = 'http://www.vimeo.com/7100569';
+        var videoUrl = 'https://www.vimeo.com/288344114';
 
         // This is the oEmbed endpoint for Vimeo (we're using JSON)
         // (Vimeo also supports oEmbed discovery. See the PHP example.)

--- a/oembed/php-example.php
+++ b/oembed/php-example.php
@@ -6,7 +6,7 @@ You may want to use oEmbed discovery instead of hard-coding the oEmbed endpoint.
 $oembed_endpoint = 'http://vimeo.com/api/oembed';
 
 // Grab the video url from the url, or use default
-$video_url = ($_GET['url']) ? $_GET['url'] : 'http://vimeo.com/7100569';
+$video_url = ($_GET['url']) ? $_GET['url'] : 'http://vimeo.com/288344114';
 
 // Create the URLs
 $json_url = $oembed_endpoint . '.json?url=' . rawurlencode($video_url) . '&width=640';

--- a/oembed/php-example.php
+++ b/oembed/php-example.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 /*
 You may want to use oEmbed discovery instead of hard-coding the oEmbed endpoint.


### PR DESCRIPTION
The formerly used video (7100569) doesn't exist anymore, hence we get a 404 error. With an actual video ID, the JS example is still working.